### PR TITLE
feat: add previous and next page  buttons

### DIFF
--- a/partselector.py
+++ b/partselector.py
@@ -329,7 +329,6 @@ class PartSelectorDialog(wx.Dialog):
         prev_button = wx.Button(self.previous_next_panel, label = "Previous",size=(70, 26))
         sizer.Add(prev_button, 0, wx.ALL, 5)
 
-        # Create a font with your desired attributes (size, style, weight)
         font = wx.Font(14, wx.DEFAULT, wx.FONTSTYLE_NORMAL, wx.NORMAL)
         container = wx.Panel(self.previous_next_panel, size=(50, 24))
         self.page_label = wx.StaticText(container, label="1/20", style=wx.ALIGN_CENTER)
@@ -337,7 +336,6 @@ class PartSelectorDialog(wx.Dialog):
         container_sizer = wx.BoxSizer(wx.VERTICAL)
         container_sizer.AddStretchSpacer(1)  
         container_sizer.Add(self.page_label, 0, wx.ALIGN_CENTER) 
-        # Set the container's sizer
         container.SetSizer(container_sizer)
         sizer.Add(container, 0, wx.ALL, 5)
         next_button = wx.Button(self.previous_next_panel, label="Next",size=(70, 26))
@@ -351,7 +349,6 @@ class PartSelectorDialog(wx.Dialog):
         # self.page_label.SetLabel(f"({default_choice})")
         # sizer.Add(self.choice, 0, wx.ALL, 5)
 
-        # Set up the Sizer and adjust the layout
         self.previous_next_panel.SetSizer(sizer)
         self.Layout()
 

--- a/partselector.py
+++ b/partselector.py
@@ -475,7 +475,7 @@ class PartSelectorDialog(wx.Dialog):
             "supplierSort": []
         }
         
-        url = "http://127.0.0.1:10000/edapluginsapi/v1/stock/search"
+        url = "https://edaapi.nextpcb.com/edapluginsapi/v1/stock/search"
         self.search_button.Disable()
         try:
             #wx.MessageBox(f"explain：{self.search_api_request(url, body)}", "Help", style=wx.ICON_INFORMATION)
@@ -563,7 +563,7 @@ class PartSelectorDialog(wx.Dialog):
             # if idx > 50 :
                 # break
             part = []
-            wx.MessageBox(f"partinfo{part_info}", "Help", style=wx.ICON_INFORMATION)
+            #wx.MessageBox(f"partinfo{part_info}", "Help", style=wx.ICON_INFORMATION)
             for k in parameters:
                 #wx.MessageBox(f"k{k}", "Help", style=wx.ICON_INFORMATION)
                 val = part_info.get(k, "")

--- a/partselector.py
+++ b/partselector.py
@@ -3,11 +3,13 @@ import wx
 import requests
 import threading
 import json
-import math
 from .events import AssignPartsEvent, UpdateSetting
 from .helpers import HighResWxSize, loadBitmapScaled
 from .partdetails import PartDetailsDialog
 from requests.exceptions import Timeout
+
+def ceil(x, y):
+    return -(-x // y)
 
 class PartSelectorDialog(wx.Dialog):
     def __init__(self, parent, parts):
@@ -420,6 +422,7 @@ class PartSelectorDialog(wx.Dialog):
         ]:
             if word:
                 search_keyword += str(word + " ")
+                
         if self.current_page == 0:
             self.current_page = 1 
         body = {
@@ -494,7 +497,7 @@ class PartSelectorDialog(wx.Dialog):
         if self.search_part_list is None:
             return
         
-        self.total_pages =  math.ceil(self.total_num / 100)
+        self.total_pages = ceil(self.total_num, 100)
         self.update_page_label()
         self.result_count.SetLabel(f"{self.total_num} Results")
         if self.total_num >= 1000:


### PR DESCRIPTION
The purpose is to incorporate previous and next page buttons into 'NextPCB Search Online'. You can click these buttons to browse the parts list.